### PR TITLE
Introducing the data frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-any"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "073375684a58dece169afbdc9879a027f3698118ad3814938316c6002b7aa921"
+
+[[package]]
 name = "critical-section"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,15 @@ dependencies = [
  "rand",
  "serde",
  "tokio",
+]
+
+[[package]]
+name = "flip-flop-data"
+version = "0.1.0"
+dependencies = [
+ "crc-any",
+ "postcard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,29 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "blobby",
+ "generic-array",
+ "heapless",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blobby"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +100,18 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "ccm"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9cf981c7e62b6fb02225592ee7ebf221e0b0b5317984a57a1e9d21af20e317"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
 
 [[package]]
 name = "cfg-if"
@@ -89,6 +130,15 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -113,10 +163,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc-any"
-version = "2.4.1"
+name = "cpufeatures"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073375684a58dece169afbdc9879a027f3698118ad3814938316c6002b7aa921"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "critical-section"
@@ -128,6 +181,15 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "riscv",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -156,9 +218,22 @@ dependencies = [
 name = "flip-flop-data"
 version = "0.1.0"
 dependencies = [
- "crc-any",
+ "aead",
+ "aes",
+ "ccm",
+ "heapless",
  "postcard",
  "serde",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -328,6 +403,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking_lot"
@@ -569,6 +650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +728,12 @@ checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "app",
+    "data"
 ]

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["huntc <huntchr@gmail.com>"]
+edition = "2021"
+readme = "README.md"
+name = "flip-flop-data"
+version = "0.1.0"
+
+[dependencies]
+crc-any = { version = "2.4.1", default-features = false }
+serde = { version = "1.0.126", default-features = false }
+
+[dev-dependencies]
+postcard = "0.7.0"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -6,8 +6,11 @@ name = "flip-flop-data"
 version = "0.1.0"
 
 [dependencies]
-crc-any = { version = "2.4.1", default-features = false }
 serde = { version = "1.0.126", default-features = false }
 
 [dev-dependencies]
-postcard = "0.7.0"
+aes = { version = "0.7", features = ["force-soft"] }
+aead = { version = "0.4", features = ["dev"], default-features = false }
+ccm = { version = "0.4", default-features = false, features = ["heapless"] }
+heapless = "0.7"
+postcard = "0.7"

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+# flip-flop-data
+
+This is a simple packet format for communicating flip-flop-app commands and events over a network. The "data" component refers to the OSI data-link layer.

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,0 +1,108 @@
+#![cfg_attr(not(test), no_std)]
+#![doc = include_str!("../README.md")]
+
+use crc_any::CRCu8;
+use serde::{Deserialize, Serialize};
+
+/// Indicates where data is sourced from.
+#[derive(Debug, PartialEq)]
+pub enum DataSource {
+    Client,
+    Server,
+}
+
+/// A data frame encapsulates client and server packets
+/// and provides for error checking.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct DataFrame<'a> {
+    // Bits as follows:
+    // 0..=1 protocol version - should be 0
+    // 2..=2 source 0 = client, 1 = server
+    // 3..=7 server address
+    // 8..=9 server port
+    // 10..=15 crc
+    header: u16,
+    data: &'a [u8],
+}
+
+/// There was an error parsing the data frame. Possibly due
+/// to an incompatible data frame version or the checksum
+/// was invalid.
+#[derive(Debug, PartialEq)]
+pub struct ParseError {}
+
+impl<'a> DataFrame<'a> {
+    /// Create a new dataframe. A CRCu8 computer is provided so that the
+    /// frame's 6 bit CRC can be determined. Note that any bits beyond
+    /// the 6th will be discarded.
+    pub fn new(
+        mut crc_computer: CRCu8,
+        source: DataSource,
+        server_address: u8,
+        server_port: u8,
+        data: &'a [u8],
+    ) -> Self {
+        let source = if source == DataSource::Client { 0 } else { 1 };
+        crc_computer.digest(data);
+        let crc = crc_computer.get_crc();
+        Self {
+            header: (source << 2)
+                | (((server_address as u16) & 0x1F) << 3)
+                | (((server_port as u16) & 0x03) << 8)
+                | ((crc as u16) << 10),
+            data,
+        }
+    }
+
+    /// Parse the contents of the data frame passing in a 6 bit CRC
+    /// If the data frame version is an incompatible value or the
+    /// CRC check fails then an error is returned. Otherwise, the
+    /// data source, server address, server port and data is retu
+    pub fn parse(
+        &self,
+        mut crc_computer: CRCu8,
+    ) -> Result<(DataSource, u8, u8, &'a [u8]), ParseError> {
+        let version = self.header & 0x02;
+        let source = match (self.header >> 2) & 0x01 {
+            0 => Some(DataSource::Client),
+            1 => Some(DataSource::Server),
+            _ => None,
+        };
+        let server_address = (self.header >> 3) & 0x1f;
+        let server_port = (self.header >> 8) & 0x03;
+        let header_crc = self.header >> 10;
+        crc_computer.digest(self.data);
+        let crc = crc_computer.get_crc();
+
+        match (version, source, header_crc as u8 == crc) {
+            (0, Some(source), true) => {
+                Ok((source, server_address as _, server_port as _, self.data))
+            }
+            _ => Err(ParseError {}),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_serde() {
+        let data = b"some data";
+
+        let expected_frame = DataFrame::new(CRCu8::crc6itu(), DataSource::Server, 31, 2, data);
+        assert_eq!(
+            expected_frame,
+            DataFrame {
+                //        FEDCBA_98_76543_2_10
+                header: 0b000001_10_11111_1_00_u16,
+                data: b"some data",
+            }
+        );
+
+        let expected_parts: Result<(DataSource, u8, u8, &[u8]), ParseError> =
+            Ok((DataSource::Server, 31_u8, 2_u8, data));
+        assert_eq!(expected_frame.parse(CRCu8::crc6itu()), expected_parts);
+    }
+}

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,14 +1,37 @@
 #![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
 
-use crc_any::CRCu8;
 use serde::{Deserialize, Serialize};
 
-/// Indicates where data is sourced from.
-#[derive(Debug, PartialEq)]
+/// Indicates where data is sourced from i.e. its direction.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum DataSource {
     Client,
     Server,
+}
+
+/// There was an error parsing the data frame. Possibly due
+/// to an incompatible data frame version.
+/// was invalid.
+#[derive(Debug, PartialEq)]
+pub struct ParseError {}
+
+/// The haader fields of the data frame.
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct Header {
+    /// The protocol version. Should be 0.
+    pub version: u8,
+    /// The direction of data flow.
+    pub source: DataSource,
+    /// The address of the server 0..31.
+    pub server_address: u8,
+    /// The port of the server 0..3.
+    pub server_port: u8,
+    /// A frame counter for ensuring message authenticity by
+    /// being able to vary a nonce. Should be incremented by
+    /// the message source and is expected to overflow to zero
+    /// after 0x3F (5 bits).
+    pub frame_counter: u32,
 }
 
 /// A data frame encapsulates client and server packets
@@ -16,52 +39,40 @@ pub enum DataSource {
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct DataFrame<'a> {
     // Bits as follows:
-    // 0..=1 protocol version - should be 0
-    // 2..=2 source 0 = client, 1 = server
-    // 3..=7 server address
-    // 8..=9 server port
-    // 10..=15 crc
-    header: u16,
-    data: &'a [u8],
+    // 0..=1   protocol version
+    // 2..=2   source 0 = client, 1 = server
+    // 3..=7   server address
+    // 8..=9   server port
+    // 10..=15 frame counter
+    header: u32,
+    // Payload data appended with a Message Integrity Check (MIC).
+    encrypted_payload: &'a [u8],
 }
 
-/// There was an error parsing the data frame. Possibly due
-/// to an incompatible data frame version or the checksum
-/// was invalid.
-#[derive(Debug, PartialEq)]
-pub struct ParseError {}
-
 impl<'a> DataFrame<'a> {
-    /// Create a new dataframe. A CRCu8 computer is provided so that the
-    /// frame's 6 bit CRC can be determined. Note that any bits beyond
-    /// the 6th will be discarded.
-    pub fn new(
-        mut crc_computer: CRCu8,
-        source: DataSource,
-        server_address: u8,
-        server_port: u8,
-        data: &'a [u8],
-    ) -> Self {
-        let source = if source == DataSource::Client { 0 } else { 1 };
-        crc_computer.digest(data);
-        let crc = crc_computer.get_crc();
+    /// Create a new dataframe with an encrypted payload inclusive of its MIC which
+    /// is expected to be appended at the end.
+    pub fn new(header: &'a Header, encrypted_payload: &'a [u8]) -> Self {
+        let source = if header.source == DataSource::Client {
+            0
+        } else {
+            1
+        };
         Self {
             header: (source << 2)
-                | (((server_address as u16) & 0x1F) << 3)
-                | (((server_port as u16) & 0x03) << 8)
-                | ((crc as u16) << 10),
-            data,
+                | (((header.server_address as u32) & 0x1F) << 3)
+                | (((header.server_port as u32) & 0x03) << 8)
+                | (((header.frame_counter as u32) & 0x3F) << 10),
+            encrypted_payload,
         }
     }
 
-    /// Parse the contents of the data frame passing in a 6 bit CRC
-    /// If the data frame version is an incompatible value or the
-    /// CRC check fails then an error is returned. Otherwise, the
-    /// data source, server address, server port and data is retu
-    pub fn parse(
-        &self,
-        mut crc_computer: CRCu8,
-    ) -> Result<(DataSource, u8, u8, &'a [u8]), ParseError> {
+    /// Parse the contents of the data frame.
+    /// If the data frame version is an incompatible value
+    /// then an error is returned. Otherwise, the header
+    /// and encrypted payload (including a MIC at the end)
+    /// are returned.
+    pub fn parse(&self) -> Result<(Header, &'a [u8]), ParseError> {
         let version = self.header & 0x02;
         let source = match (self.header >> 2) & 0x01 {
             0 => Some(DataSource::Client),
@@ -70,14 +81,19 @@ impl<'a> DataFrame<'a> {
         };
         let server_address = (self.header >> 3) & 0x1f;
         let server_port = (self.header >> 8) & 0x03;
-        let header_crc = self.header >> 10;
-        crc_computer.digest(self.data);
-        let crc = crc_computer.get_crc();
+        let frame_counter = (self.header >> 10) & 0x3f;
 
-        match (version, source, header_crc as u8 == crc) {
-            (0, Some(source), true) => {
-                Ok((source, server_address as _, server_port as _, self.data))
-            }
+        match (version, source) {
+            (0, Some(source)) => Ok((
+                Header {
+                    version: 0,
+                    source,
+                    server_address: server_address as _,
+                    server_port: server_port as _,
+                    frame_counter,
+                },
+                self.encrypted_payload,
+            )),
             _ => Err(ParseError {}),
         }
     }
@@ -86,23 +102,91 @@ impl<'a> DataFrame<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aes::Aes128;
+    use ccm::aead::AeadInPlace;
+    use ccm::aead::{generic_array::GenericArray, NewAead};
+    use ccm::{
+        consts::{U4, U8},
+        Ccm,
+    };
+    use heapless::Vec;
 
     #[test]
-    fn test_command_serde() {
-        let data = b"some data";
+    fn test_command_serialisation() {
+        type AesCcm = Ccm<Aes128, U4, U8>;
 
-        let expected_frame = DataFrame::new(CRCu8::crc6itu(), DataSource::Server, 31, 2, data);
+        let key = GenericArray::from_slice(b"0123456789ABCDEF");
+        let cipher = AesCcm::new(key);
+
+        let header = Header {
+            version: 0,
+            source: DataSource::Server,
+            server_address: 31,
+            server_port: 2,
+            frame_counter: 1,
+        };
+
+        let mut nonce = [0; 8];
+        let _ = postcard::to_slice(&header, &mut nonce).unwrap();
+        let nonce = GenericArray::from_slice(&nonce);
+
+        let payload = b"some data";
+        let mut encrypted_payload: Vec<u8, 128> = Vec::new();
+        let _ = encrypted_payload.extend_from_slice(payload).unwrap();
+        let _ = cipher
+            .encrypt_in_place(nonce, b"", &mut encrypted_payload)
+            .unwrap();
+
+        let expected_frame = DataFrame::new(&header, &encrypted_payload);
         assert_eq!(
             expected_frame,
             DataFrame {
                 //        FEDCBA_98_76543_2_10
-                header: 0b000001_10_11111_1_00_u16,
-                data: b"some data",
+                header: 0b000001_10_11111_1_00,
+                encrypted_payload: &[91, 146, 159, 160, 124, 31, 21, 57, 196, 230, 143, 129, 18],
             }
         );
+    }
 
-        let expected_parts: Result<(DataSource, u8, u8, &[u8]), ParseError> =
-            Ok((DataSource::Server, 31_u8, 2_u8, data));
-        assert_eq!(expected_frame.parse(CRCu8::crc6itu()), expected_parts);
+    #[test]
+    fn test_command_deserialisation() {
+        type AesCcm = Ccm<Aes128, U4, U8>;
+
+        let key = GenericArray::from_slice(b"0123456789ABCDEF");
+        let cipher = AesCcm::new(key);
+
+        let data_frame = DataFrame {
+            //        FEDCBA_98_76543_2_10
+            header: 0b000001_10_11111_1_00,
+            encrypted_payload: &[91, 146, 159, 160, 124, 31, 21, 57, 196, 230, 143, 129, 18],
+        };
+
+        let (header, encrypted_payload) = data_frame.parse().unwrap();
+
+        let expected_header = Header {
+            version: 0,
+            source: DataSource::Server,
+            server_address: 31,
+            server_port: 2,
+            frame_counter: 1,
+        };
+
+        assert_eq!(header, expected_header);
+
+        let mut nonce = [0; 8];
+        let _ = postcard::to_slice(&header, &mut nonce).unwrap();
+        let nonce = GenericArray::from_slice(&nonce);
+
+        let mut decrypted_payload: Vec<u8, 128> = Vec::new();
+        let _ = decrypted_payload
+            .extend_from_slice(encrypted_payload)
+            .unwrap();
+        let _ = cipher
+            .decrypt_in_place(nonce, b"", &mut decrypted_payload)
+            .unwrap();
+
+        let expected_payload = b"some data";
+
+        assert_eq!(decrypted_payload, expected_payload);
     }
 }

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Header {
     pub source: DataSource,
     /// The address of the server 0..31.
     pub server_address: u8,
-    /// The port of the server 0..3.
+    /// The port of the server 0..31.
     pub server_port: u8,
     /// A frame counter for ensuring message authenticity by
     /// being able to vary a nonce. Should be incremented by
@@ -42,8 +42,8 @@ pub struct DataFrame<'a> {
     // 0..=1   protocol version
     // 2..=2   source 0 = client, 1 = server
     // 3..=7   server address
-    // 8..=9   server port
-    // 10..=15 reserved - must be zero
+    // 8..=12  server port
+    // 13..=15 reserved - must be zero
     // 16..=31 frame counter
     header: u32,
     // Payload data appended with a Message Authentication Code (MAC).
@@ -62,7 +62,7 @@ impl<'a> DataFrame<'a> {
         Self {
             header: (source << 2)
                 | (((header.server_address as u32) & 0x1F) << 3)
-                | (((header.server_port as u32) & 0x03) << 8)
+                | (((header.server_port as u32) & 0x1F) << 8)
                 | (((header.frame_counter as u32) & 0xFFFF) << 16),
             encrypted_payload,
         }
@@ -81,7 +81,7 @@ impl<'a> DataFrame<'a> {
             _ => None,
         };
         let server_address = (self.header >> 3) & 0x1F;
-        let server_port = (self.header >> 8) & 0x03;
+        let server_port = (self.header >> 8) & 0x1F;
         let frame_counter = (self.header >> 16) & 0xFFFF;
 
         match (version, source) {

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -45,12 +45,12 @@ pub struct DataFrame<'a> {
     // 8..=9   server port
     // 10..=15 frame counter
     header: u32,
-    // Payload data appended with a Message Integrity Check (MIC).
+    // Payload data appended with a Message Authentication Code (MAC).
     encrypted_payload: &'a [u8],
 }
 
 impl<'a> DataFrame<'a> {
-    /// Create a new dataframe with an encrypted payload inclusive of its MIC which
+    /// Create a new dataframe with an encrypted payload inclusive of its MAC which
     /// is expected to be appended at the end.
     pub fn new(header: &'a Header, encrypted_payload: &'a [u8]) -> Self {
         let source = if header.source == DataSource::Client {
@@ -70,7 +70,7 @@ impl<'a> DataFrame<'a> {
     /// Parse the contents of the data frame.
     /// If the data frame version is an incompatible value
     /// then an error is returned. Otherwise, the header
-    /// and encrypted payload (including a MIC at the end)
+    /// and encrypted payload (including a MAC at the end)
     /// are returned.
     pub fn parse(&self) -> Result<(Header, &'a [u8]), ParseError> {
         let version = self.header & 0x02;

--- a/flip-flop-protocol.code-workspace
+++ b/flip-flop-protocol.code-workspace
@@ -1,7 +1,10 @@
 {
 	"folders": [
 		{
-			"path": "app"
+			"path": "app",
+		},
+		{
+			"path": "data",
 		},
 	],
 	"settings": {


### PR DESCRIPTION
This PR introduces the data frame to convey flip-flop-app payloads. A means to version the protocol, determine the source of the frame (client/server), the server address and port and Message Authentication Code (MAC) to authenticate the data are all provided.