### PR TITLE
Replaces the mandatory traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flip-flop is an OSI-style application layer protocol optimised for half-duplex c
 
 Commands instruct a server to do something, normally resulting in an event. All commands convey an offset to the last event that the client received so that a server knows the next event it should reply with. Commands are use-definable.
 
-There is a mandatory command that permits the client to get an event. A client may issue this command repeatedly during intialisation with a server so that it may retrieve its events. A client may also issue this command at a regular interval to poll for new events e.g. when there are no other commands to issue.
+The absence of a command payload signifies a mandatory command that permits the client to get an event. A client may issue this command repeatedly during intialisation with a server so that it may retrieve its events. A client may also issue this command at a regular interval to poll for new events e.g. when there are no other commands to issue.
 
 A server maintains a history of events which may or may not be in relation to the processing of a command received. Events are designated with an offset and are user-definable. Events also convey a time delta relative to the time at being served to diminish the effects of clock drift betweeen a client and server. A client may then normalise an event's time with its own clock.
 
@@ -15,7 +15,7 @@ A server replies to a command with the next "nearest" event. The "nearest" event
 Offsets are held as an unsigned 32 bit integer and may overflow to zero. In the situation of having overflowed, a client must forget all prior events and a server must ensure that any important events are re-sent. A client may detect this
 situation by checking whether the received offset is less than or equal to the one it has.
 
-There is a mandatory event that permits the server to indicate that there are no more events to be replied. This event assists a client in being able to retrieve a history of events during the initialisation with a server.
+The absence of an event payload signifies a mandatory event that permits the server to indicate that there are no more events to be replied. This event assists a client in being able to retrieve a history of events during the initialisation with a server.
 
 A simplified link layer protocol is also provided by this project so that flip-flop can be used where IP networks are not present e.g. with serial communications such as RS-485. This data layer provides a server address, a server port, an opaque variable length payload, and a CRC for error checking.
 

--- a/app/examples/common/lib.rs
+++ b/app/examples/common/lib.rs
@@ -1,26 +1,11 @@
-use flip_flop_app::{MandatoryCommands, MandatoryEvents};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Command {
-    NextEvent,
     SomeCommand,
-}
-
-impl MandatoryCommands for Command {
-    fn next_event() -> Self {
-        Command::NextEvent
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Event {
-    NoMoreEvents,
     SomeEvent,
-}
-
-impl MandatoryEvents for Event {
-    fn no_more_events() -> Self {
-        Event::NoMoreEvents
-    }
 }

--- a/app/examples/server/main.rs
+++ b/app/examples/server/main.rs
@@ -64,13 +64,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     // offset exceeds the last one observed by the client. In the
                     // case where we have no last offset expressed by the client
                     // then we provide the oldest one we have.
-                    let maybe_reply = match request.last_event_offset {
-                        Some(last_event_offset) => events
+                    let maybe_reply = events
                             .iter()
-                            .take_while(|(_, offset, _)| *offset > last_event_offset)
-                            .last(),
-                        None => events.iter().last(),
-                    };
+                            .take_while(|(_, offset, _)| *offset > request.last_event_offset)
+                            .last().or_else(|| events.iter().next());
 
                     let reply = flip_flop_app::event_reply(maybe_reply, |t|Instant::now().duration_since(t).as_secs());
 


### PR DESCRIPTION
In place of the mandatory traits we had, we now omit the command and event payloads in the case of where we are requesting the next events and replying the next event respectively. Serde has been leveraged to omit serialising an option's Some value when it is positioned at the end of a struct. Similarly, deserialisation tolerates the lack of these bytes resulting in a None type accordingly.