### PR TITLE
Introduces a software update protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,10 +289,12 @@ dependencies = [
  "aead",
  "aes",
  "ccm",
+ "defmt",
  "futures",
  "heapless",
  "postcard",
  "rand",
+ "semver 1.0.14",
  "serde",
  "tokio",
 ]
@@ -591,6 +622,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 aead = { version = "0.5", default-features = false }
+defmt = { version = "0.3", optional = true }
 heapless = "0.7"
 postcard = "1.0"
 rand = { version = "0.8", default-features = false }
@@ -18,4 +19,8 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 ccm = { version = "0.5", default-features = false, features = ["heapless"] }
 futures = "0.3"
 rand = "0.8"
+semver = { version = "1.0.14", default-features = false }
 tokio = { version = "1", features = ["full"] }
+
+[features]
+defmt = ["dep:defmt"]

--- a/data/examples/update/main.rs
+++ b/data/examples/update/main.rs
@@ -1,0 +1,391 @@
+use std::time::Duration;
+
+use aead::KeyInit;
+use aes::Aes128;
+use ccm::aead::generic_array::GenericArray;
+use ccm::aead::AeadInPlace;
+use ccm::{
+    consts::{U4, U7},
+    Ccm,
+};
+use flip_flop_data::discovery::MIN_PACKET_SIZE;
+use flip_flop_data::{
+    discovery::MIN_PAYLOAD_SIZE,
+    from_datagram, to_datagram,
+    update::{PrepareForUpdate, Update, UpdateKey, Version, UPDATE_BYTES_OVERHEAD},
+    DataSource, Header,
+};
+use rand::RngCore;
+use semver::Version as SemVer;
+use tokio::sync::broadcast;
+use tokio::time;
+
+type AesCcm = Ccm<Aes128, U4, U7>;
+
+// Our software update bytes.
+static UPDATE: [u8; 100 * 1024] = [0u8; 100 * 1024];
+
+// The port that a server is associated with.
+const MY_APP_PORT: u8 = 2;
+
+// This would normally consider the time on wire for a request and the time taken
+// for a server to process it. Consideration for replies is not required as they
+// will be no reply.
+const SERVER_REQUEST_RECEIVE_TIME: Duration = Duration::from_millis(12);
+
+// The amount of time we must periodically wait for a server to do what it must
+// to process the bytes we've sent. This period should include both the time
+// taken to transmit the bytes and the time allowed for a server to do its thing
+// e.g. write the bytes it has buffered into flash storage.
+const UPDATE_PROCESSING_TIME: Duration = Duration::from_millis(100);
+
+// The number of bytes that gets sent with each update.
+const UPDATE_BYTES_SIZE: usize = MIN_PAYLOAD_SIZE - UPDATE_BYTES_OVERHEAD;
+
+// The number of bytes sent before we must pause and give the
+// servers more time to process. This value must not be exceeded.
+const UPDATE_BYTES_PROCESSING_THRESHOLD: usize = 4096;
+
+mod client {
+
+    use super::*;
+
+    pub async fn task(tx: &broadcast::Sender<[u8; MIN_PACKET_SIZE]>, servers: &[(u8, [u8; 16])]) {
+        let mut datagram_buf = [0u8; MIN_PACKET_SIZE];
+        let mut frame_counter = 0;
+
+        let mut rng = rand::thread_rng();
+        let mut update_key = [0; 16];
+        rng.fill_bytes(&mut update_key);
+
+        let update_len = UPDATE.len();
+
+        prepare_servers_for_update(
+            tx,
+            servers,
+            &update_key,
+            update_len,
+            &mut frame_counter,
+            &mut datagram_buf,
+        )
+        .await;
+
+        update_servers(
+            tx,
+            &update_key,
+            update_len,
+            &mut frame_counter,
+            &mut datagram_buf,
+        )
+        .await;
+    }
+
+    async fn prepare_servers_for_update(
+        tx: &broadcast::Sender<[u8; MIN_PACKET_SIZE]>,
+        servers: &[(u8, [u8; 16])],
+        update_key: &[u8; 16],
+        update_len: usize,
+        frame_counter: &mut u16,
+        datagram_buf: &mut [u8; MIN_PACKET_SIZE],
+    ) {
+        for (server_address, server_network_key) in servers {
+            let server_network_cipher = AesCcm::new(GenericArray::from_slice(server_network_key));
+
+            let prepare_for_update = PrepareForUpdate {
+                version: Version {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                    pre: None,
+                },
+                server_ports: 1 << MY_APP_PORT,
+                update_key: UpdateKey(*update_key),
+                update_byte_len: update_len as u32,
+            };
+
+            create_prepare_update_request(
+                &server_network_cipher,
+                &prepare_for_update,
+                *frame_counter,
+                datagram_buf,
+            );
+
+            // We're sending to just one server, but ordinarily, many servers would receive it.
+            if tx.send(*datagram_buf).is_ok() {
+                println!("CLIENT {frame_counter}: sent prepare for update request to {server_address}. Waiting for the server to process.");
+                *frame_counter = frame_counter.wrapping_add(1);
+
+                // We provide each server with enough time to process along with the time it takes to send our bytes on the wire.
+                time::sleep(SERVER_REQUEST_RECEIVE_TIME).await;
+            }
+        }
+    }
+
+    fn create_prepare_update_request(
+        network_cipher: &impl AeadInPlace,
+        prepare_for_update: &PrepareForUpdate,
+        frame_counter: u16,
+        datagram_buf: &mut [u8; MIN_PACKET_SIZE],
+    ) {
+        let header = Header {
+            version: 0,
+            source: DataSource::Client,
+            server_address: 0,
+            server_port: 1,
+            frame_counter,
+        };
+
+        to_datagram(
+            network_cipher,
+            &header,
+            &postcard::to_vec::<PrepareForUpdate, MIN_PAYLOAD_SIZE>(prepare_for_update).unwrap(),
+            datagram_buf,
+        );
+    }
+
+    async fn update_servers(
+        tx: &broadcast::Sender<[u8; MIN_PACKET_SIZE]>,
+        update_key: &[u8; 16],
+        update_len: usize,
+        frame_counter: &mut u16,
+        datagram_buf: &mut [u8; MIN_PACKET_SIZE],
+    ) {
+        let update_cipher = AesCcm::new(GenericArray::from_slice(update_key));
+
+        let mut update_byte_offset = 0;
+        let mut next_threshold_byte_offset = UPDATE_BYTES_PROCESSING_THRESHOLD.min(update_len);
+
+        while update_byte_offset < UPDATE.len() {
+            let to_update_byte_offset =
+                (update_byte_offset + UPDATE_BYTES_SIZE).min(next_threshold_byte_offset);
+            let update_bytes = &UPDATE[update_byte_offset..to_update_byte_offset];
+
+            let update: Update<UPDATE_BYTES_SIZE> = Update {
+                byte_offset: update_byte_offset as u32,
+                bytes: heapless::Vec::from_slice(update_bytes).unwrap(),
+            };
+
+            create_update_request(&update_cipher, &update, *frame_counter, datagram_buf);
+
+            if tx.send(*datagram_buf).is_err() {
+                return;
+            }
+
+            let delay = if to_update_byte_offset == next_threshold_byte_offset {
+                next_threshold_byte_offset += UPDATE_BYTES_PROCESSING_THRESHOLD;
+                next_threshold_byte_offset = next_threshold_byte_offset.min(update_len);
+                UPDATE_PROCESSING_TIME
+            } else {
+                SERVER_REQUEST_RECEIVE_TIME
+            };
+
+            println!("CLIENT {frame_counter}: sent update with offset {update_byte_offset} with len {}. Waiting {:?} for the server to process.", update_bytes.len(), delay);
+            time::sleep(delay).await;
+
+            *frame_counter = frame_counter.wrapping_add(1);
+
+            update_byte_offset = to_update_byte_offset;
+        }
+
+        println!(
+            "CLIENT {frame_counter}: sent updates Waiting {:?} for the server to process.",
+            UPDATE_PROCESSING_TIME
+        );
+        time::sleep(UPDATE_PROCESSING_TIME).await;
+    }
+
+    fn create_update_request<const N: usize>(
+        update_cipher: &impl AeadInPlace,
+        update: &Update<N>,
+        frame_counter: u16,
+        datagram_buf: &mut [u8; MIN_PACKET_SIZE],
+    ) {
+        let header = Header {
+            version: 0,
+            source: DataSource::Client,
+            server_address: 0,
+            server_port: 1,
+            frame_counter,
+        };
+
+        to_datagram(
+            update_cipher,
+            &header,
+            &postcard::to_vec::<Update<N>, MIN_PAYLOAD_SIZE>(update).unwrap(),
+            datagram_buf,
+        );
+    }
+}
+
+mod server {
+
+    use flip_flop_data::update::PreRelease;
+
+    use super::*;
+
+    struct UpdateInfo {
+        cipher: AesCcm,
+        byte_len: usize,
+        next_byte_offset: usize,
+    }
+
+    pub async fn task(tx: broadcast::Sender<[u8; MIN_PACKET_SIZE]>, server: &(u8, [u8; 16])) {
+        let mut rx = tx.subscribe();
+
+        let (_server_address, server_network_key) = server;
+        let server_cipher = AesCcm::new(GenericArray::from_slice(server_network_key));
+
+        let current_version = SemVer::new(1, 2, 0);
+        let mut active_update_info: Option<UpdateInfo> = None;
+
+        while let Ok(encrypted_payload) = rx.recv().await {
+            // First try processing an update request for an active update
+            if let Some((update_info, update)) = if let Some(update_info) = &mut active_update_info
+            {
+                process_client_update_request::<UPDATE_BYTES_SIZE>(
+                    &update_info.cipher,
+                    &encrypted_payload,
+                )
+                .map(|update| (update_info, update))
+            } else {
+                None
+            } {
+                if process_active_update(update_info, &update) {
+                    active_update_info = None;
+                    continue;
+                }
+
+            // If we're not processing an active update then try handling the
+            // request as one that prepares us for a new update.
+            } else if let Some(prepare_for_update) =
+                process_client_prepare_for_update_request(&server_cipher, &encrypted_payload)
+            {
+                if let Some(new_active_update_info) =
+                    activate_update_if_new_version(&prepare_for_update, &current_version)
+                {
+                    active_update_info = Some(new_active_update_info);
+                }
+            }
+        }
+    }
+
+    fn process_client_update_request<const N: usize>(
+        cipher: &AesCcm,
+        datagram_buf: &[u8; MIN_PACKET_SIZE],
+    ) -> Option<Update<N>> {
+        from_datagram(
+            datagram_buf,
+            |h| h.server_address == 0x00 && h.server_port == 0x01 && h.source == DataSource::Client,
+            cipher,
+        )
+        .and_then(|(_, b)| postcard::from_bytes::<Update<N>>(&b).ok())
+    }
+
+    fn process_active_update<const N: usize>(
+        update_info: &mut UpdateInfo,
+        update: &Update<N>,
+    ) -> bool {
+        // Bail out if the next byte offset isn't what we expect.
+        if update.byte_offset as usize != update_info.next_byte_offset {
+            println!(
+                "SERVER: abandoning update given unexpected offset {} with len {}.",
+                update.byte_offset,
+                update.bytes.len()
+            );
+            return true;
+        }
+
+        println!(
+            "SERVER: received update with offset {} with len {}.",
+            update.byte_offset,
+            update.bytes.len()
+        );
+
+        update_info.next_byte_offset += update.bytes.len();
+
+        if update_info.next_byte_offset == update_info.byte_len {
+            println!("SERVER: Doing something heavy with the last bytes of our buffer e.g. flashing memory with firmware.");
+
+            println!("SERVER: {} bytes received. Update finished. Do something heavy again e.g. update firmware.", update_info.next_byte_offset);
+            true
+        } else if update_info.next_byte_offset % UPDATE_BYTES_PROCESSING_THRESHOLD == 0 {
+            println!(
+                "SERVER: Doing something heavy with our buffer e.g. flashing memory with firmware."
+            );
+            false
+        } else {
+            false
+        }
+    }
+
+    fn process_client_prepare_for_update_request(
+        cipher: &AesCcm,
+        datagram_buf: &[u8; MIN_PACKET_SIZE],
+    ) -> Option<PrepareForUpdate> {
+        from_datagram(
+            datagram_buf,
+            |h| h.server_address == 0x00 && h.server_port == 0x01 && h.source == DataSource::Client,
+            cipher,
+        )
+        .and_then(|(_, b)| postcard::from_bytes::<PrepareForUpdate>(&b).ok())
+    }
+
+    fn activate_update_if_new_version(
+        prepare_for_update: &PrepareForUpdate,
+        current_version: &SemVer,
+    ) -> Option<UpdateInfo> {
+        let update_version = semver_from(&prepare_for_update.version);
+        // Is this a version we're interested in? If so then note something about it.
+        if &update_version > current_version {
+            println!("SERVER: updating from {current_version} to {update_version}.");
+
+            Some(UpdateInfo {
+                cipher: AesCcm::new(GenericArray::from_slice(&prepare_for_update.update_key.0)),
+                byte_len: prepare_for_update.update_byte_len as usize,
+                next_byte_offset: 0,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn semver_from(version: &Version) -> SemVer {
+        let mut update_version = SemVer::new(
+            version.major as u64,
+            version.minor as u64,
+            version.patch as u64,
+        );
+        match version.pre {
+            Some(PreRelease::Alpha(ident)) => {
+                update_version.pre = semver::Prerelease::new(&format!("alpha.{}", ident)).unwrap();
+                update_version
+            }
+            Some(PreRelease::Beta(ident)) => {
+                update_version.pre = semver::Prerelease::new(&format!("beta.{}", ident)).unwrap();
+                update_version
+            }
+            _ => update_version,
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Both the client and server share a private key. Each server in a network
+    // should have its own private key.
+    let mut rng = rand::thread_rng();
+    let mut server_network_key = [0; 16];
+    rng.fill_bytes(&mut server_network_key);
+
+    let servers = vec![(1, server_network_key)];
+
+    let (tx, _rx) = broadcast::channel(256);
+
+    let task_tx = tx.clone();
+    let task_servers = servers.clone();
+    tokio::spawn(async move {
+        server::task(task_tx.clone(), &task_servers[0]).await;
+    });
+
+    client::task(&tx, &servers).await;
+}

--- a/data/src/discovery.rs
+++ b/data/src/discovery.rs
@@ -29,6 +29,7 @@ pub struct Identify {
 /// to be assigned to.
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Identified {
+    /// The server address desired by the server.
     pub server_address: u8,
     /// A bit field representing each port supported by
     /// the server e.g. bit 1 represents that port 1 is

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod discovery;
+pub mod update;
 
 use aead::{generic_array::GenericArray, AeadInPlace};
 use heapless::Vec;

--- a/data/src/update.rs
+++ b/data/src/update.rs
@@ -1,0 +1,83 @@
+use heapless::Vec;
+use serde::{Deserialize, Serialize};
+
+/// Describes a key for the purposes of update message
+/// encryption and authentication.
+#[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+pub struct UpdateKey(pub [u8; 16]);
+impl core::fmt::Debug for UpdateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("UpdateKey").field(&"XXX").finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UpdateKey {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "UpdateKey(XXX)");
+    }
+}
+
+/// A constrained form of pre-release designators along with
+/// a numeric identifer.
+#[derive(Eq, PartialEq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum PreRelease {
+    Alpha(u32),
+    Beta(u32),
+}
+
+/// A compact and limited representation of a version based on
+/// https://semver.org. In particular, there is no provision for a
+/// build identifier. Also, pre-releases are constrained to Alpha
+/// and Beta.
+#[derive(Eq, PartialEq, Deserialize, Serialize)]
+pub struct Version {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+    pub pre: Option<PreRelease>,
+}
+
+/// Prior to sending out an update, the client prepares one or more servers
+/// to receive an update. As the client knows the encryption key of
+/// a given server, it notifies it of a pending update.
+#[derive(Deserialize, Serialize)]
+pub struct PrepareForUpdate {
+    /// The semantic version of the update. A server can use this to
+    /// determine eligibility i.e. update only if greater than what
+    /// it already has.
+    pub version: Version,
+    /// Those server ports that the update applies to. A server uses
+    /// a port for a specific function. Thus, if the applicable ports
+    /// matches the server's entire capability then it may elect
+    /// to be updated. The ports are passed as bits e.g. bit 1 relates
+    /// to port 1, bit 3 relates to port 3 and so on.
+    pub server_ports: u8,
+    /// The [UpdateKey] is generated for a sequence of update messages to
+    /// follow and is used by all servers wishing to update based on this
+    /// and the version matching.
+    pub update_key: UpdateKey,
+    /// The number of bytes that comprise the
+    /// total update. This allows a server to understand if it has missed
+    /// an update message and when it has received all of them.
+    pub update_byte_len: u32,
+}
+
+/// Update payload for the purposes of a client broadcasting to the
+/// servers it has previous shared an update key with. The size of
+/// record is determined by the application.
+#[derive(Deserialize, Serialize)]
+pub struct Update<const N: usize> {
+    pub byte_offset: u32,
+    /// The update bytes themselves. Cannot exceed 127 bytes.
+    pub bytes: Vec<u8, N>,
+}
+
+/// The number of bytes in an [Update] that are not part of the
+/// `update_bytes` field. Must be used when calculating the size
+/// of the update byte vectors in relation to the maximum number
+/// of bytes that can be sent.
+/// This field presently considers the `update_byte_offset` length
+/// and one byte for the length of the `update_bytes` field. `update_bytes`
+/// cannot exceed 127 bytes.
+pub const UPDATE_BYTES_OVERHEAD: usize = 4 + 1;


### PR DESCRIPTION
A software update protocol is introduced that can be used with flip-flop. The protocol is considerate of an update being split up into many "chunks". It is also sympathetic toward microcontrollers that will take some time to write buffered update data into flash memory.

Here's a sample of the example client output:

```
CLIENT 303: sent update with offset 8146 with len 27. Waiting 12ms for the server to process.
SERVER: received update with offset 8146 with len 27.
CLIENT 304: sent update with offset 8173 with len 19. Waiting 100ms for the server to process.
SERVER: received update with offset 8173 with len 19.
SERVER: Doing something heavy with our buffer e.g. flashing memory with firmware.
CLIENT 305: sent update with offset 8192 with len 27. Waiting 12ms for the server to process.
SERVER: received update with offset 8192 with len 27.
```

`8192` is divisible by `4096`, which is the threshold of bytes where we wait a bit longer for a server to process its buffer.

I'm seeing that it takes around 25s to convey 100KiB of bytes (firmware!) when using the example.