### PR TITLE
Avoid semver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,6 @@ dependencies = [
  "heapless",
  "postcard",
  "rand",
- "semver 1.0.14",
  "serde",
  "tokio",
 ]

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -19,7 +19,6 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 ccm = { version = "0.5", default-features = false, features = ["heapless"] }
 futures = "0.3"
 rand = "0.8"
-semver = { version = "1.0.14", default-features = false }
 tokio = { version = "1", features = ["full"] }
 
 [features]


### PR DESCRIPTION
This changes here allow us to avoid the need to use the semver crate as we are able to parse our own version strings. The semver crate is not friendly to being used without an allocator.

We're also able to compare versions in accordance with the semver rules.