### PR TITLE
Make provision for digital signing verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ If a server updates its firmware as a consequence of this broadcast then it is a
 event signifying the version of the firmware it now has. The details of this event are outside of the flip-flop
 specification.
 
+### Signing
+
+The data protocol also accomodates a `signed` field. When set then the first n bytes of the update are to be interpreted as the
+digital signature. The length of the digital signature and its type are agreed between the client and server and outside of this 
+specification. It is expected that a software update should not proceed given the presence of signed data not verifying.
+
 ## Why flip-flop?
 
 Reason #1: data flow between a client and server "flip flops" i.e. the protocol is designed to be only be in one of two states of flow where either the client is sending and servers are receiving, or a server is sending and a client is receiving.

--- a/data/examples/update/main.rs
+++ b/data/examples/update/main.rs
@@ -99,6 +99,7 @@ mod client {
                 server_ports: 1 << MY_APP_PORT,
                 update_key: UpdateKey(*update_key),
                 update_byte_len: update_len as u32,
+                signed: false,
             };
 
             create_prepare_update_request(


### PR DESCRIPTION
Digital signatures such as those used by ed25519 can now be conveyed as the first n bytes of an update. If a signature is provided then this is also conveyed on the prepare-update request. The type and length of the signature are an application concern, but ed25519 is considered.

~~The reason we convey the signature up front is so that a digest can be formed by the server as bytes are received, rather than making another pass over the bytes to form a digest. For example, a SHA-512 digest is used for signing ed25519 messages.~~

I've also enhanced version parsing to accommodate semver metadata being conveyed in a version string. This allows us to express version numbers like `1.3.2-alpha.1+signed` if we wish.