### PR TITLE
Ephemeral events

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,25 @@ A command instructs a server to do something, typically resulting in an event.  
 
 Command delivery is 'best effort'.   If the transport indicates an error then the client cannot assume the command was or was not delivered.  However the client can ascertain the state of the server and recover in an application specific way.
 
-Event delivery is reliable in the face of transport errors. Other failures, such as a server restart, are detected allowing application specific recovery.  The intent of the event delivery mechanism is that the client can track the relevant state of each server, visible through its events.
+Events can be of two types: those that are "logged" and thereby durable; and those that are ephemeral and may disappear.
 
-## Event Delivery
+Logged event delivery is reliable in the face of transport errors. Other failures, such as a server restart, are detected allowing application specific recovery.  The intent of the event delivery mechanism is that the client can track the relevant state of each server, visible through its events.
 
-A numeric _offset_ is assigned to each event by the server that generates it.  The client tracks the offset of the latest event successfully received from each server.  Each command or poll sent by the client carries this offset. The server normally responds with the following event or no event if the client's offset is up to date. 
+## Logged Event Delivery
 
-A server maintains a short history of events. This enables a client to request the same event more than once, in the case of a transport error.  In general the client can fall behind the server by the length of the history. 
+A numeric _offset_ is assigned to each event by the server that generates it. The client tracks the offset of the latest event successfully received from each server.  Each command or poll sent by the client carries this offset. The server normally responds with the following logged event, or either an ephemeral event or none if the client's offset is up to date. 
 
-A loss of synchronization between client and server occurs when neither the client's offset nor its successor is found in the server's history.  This indicates an overrun where more events were generated on the server than could be stored or delivered.  Alternatively, either the client or the server may have restarted.  In either case application specific recovery may be required.   
+A server maintains a short history of logged events. This enables a client to request the same event more than once, in the case of a transport error.  In general the client can fall behind the server by the length of the history. 
 
-The protocol requires the server to deliver the oldest event in its history in this scenario.  The client detects the loss of synchronization when the received event does not have the expected offset.
+A loss of synchronization between client and server occurs when neither the client's offset nor its successor is found in the server's history.  This indicates an overrun where more logged events were generated on the server than could be stored or delivered.  Alternatively, either the client or the server may have restarted.  In either case application specific recovery may be required.   
+
+The protocol requires the server to deliver the oldest logged event in its history in this scenario.  The client detects the loss of synchronization when the received logged event does not have the expected offset.
 
 Details of offset calculation and assignment to events are given in [offset-rules.md](offset-rules.md).
 
 ## Event Times
 
-Events also convey a time delta relative to the time at being served to diminish the effects of clock drift between a client and server. A client may then normalise an event's time with its own clock.
+Both logged and ephemeral events also convey a time delta relative to the time at being served to diminish the effects of clock drift between a client and server. A client may then normalise an event's time with its own clock.
 
 ## Data Link Layer
 

--- a/app/examples/server/main.rs
+++ b/app/examples/server/main.rs
@@ -76,10 +76,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let next_e = events_iter.next();
                     let last_e = events_iter.next();
                     let maybe_event = match (next_e, last_e) {
-                        (Some((Logged(_, o), _)), _) if *o == next_event_offset => next_e,
+                        (Some((Logged(_, o), _)), _) if *o == next_event_offset => next_e.cloned(),
                         (_, Some((Logged(_, o), _))) if *o == request.last_event_offset => None,
                         (Some((Logged(_, o), _)), _) if *o == request.last_event_offset => None,
-                        _ => events.iter().last(),
+                        _ => events.iter().last().cloned(),
                     };
 
                     let reply = flip_flop_app::event_reply(maybe_event, |t|Instant::now().duration_since(t).as_secs());

--- a/app/examples/server/main.rs
+++ b/app/examples/server/main.rs
@@ -2,7 +2,7 @@ use circular_queue::CircularQueue;
 use rand::prelude::*;
 use std::{env, error::Error, net::SocketAddr, time::Duration};
 
-use flip_flop_app::CommandRequest;
+use flip_flop_app::{CommandRequest, Logged};
 use tokio::{
     net::UdpSocket,
     sync::mpsc,
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     const MAX_EVENTS: usize = 10;
 
     let mut recv_buf = [0; MAX_DATAGRAM_SIZE];
-    let mut events = CircularQueue::<(Event, u32, Instant)>::with_capacity(MAX_EVENTS);
+    let mut events = CircularQueue::<(Logged<Event>, Instant)>::with_capacity(MAX_EVENTS);
 
     // Randomise the starting offset to increase the probably of a client
     // detecting that a server has started up.
@@ -72,13 +72,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let mut events_iter =
                         events
                         .iter()
-                        .skip_while(|e| e.1 != next_event_offset && e.1 != request.last_event_offset);
+                        .skip_while(|(Logged(_, o), _)| *o != next_event_offset && *o != request.last_event_offset);
                     let next_e = events_iter.next();
                     let last_e = events_iter.next();
                     let maybe_event = match (next_e, last_e) {
-                        (Some(e), _) if e.1 == next_event_offset => next_e,
-                        (_, Some(e)) if e.1 == request.last_event_offset => None,
-                        (Some(e), _) if e.1 == request.last_event_offset => None,
+                        (Some((Logged(_, o), _)), _) if *o == next_event_offset => next_e,
+                        (_, Some((Logged(_, o), _))) if *o == request.last_event_offset => None,
+                        (Some((Logged(_, o), _)), _) if *o == request.last_event_offset => None,
                         _ => events.iter().last(),
                     };
 
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     event_offset = rand::thread_rng().gen_range(0..MAX_EVENTS) as u32;
                 } else {
                     println!("SERVER: event stored for offset {}", event_offset);
-                    events.push((Event::SomeEvent, event_offset, event_instant));
+                    events.push((Logged(Event::SomeEvent, event_offset), event_instant));
                     event_offset = event_offset.wrapping_add(1);
                 }
             }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -30,15 +30,42 @@ pub struct CommandRequest<C: DeserializeOwned + Serialize> {
     pub command: Option<C>,
 }
 
-/// An EventRequest may only be emitted by a server, of which there can be many, and
-/// only in relation to having received a [CommandRequest] from a client. Event requests
-/// take a type that provides their identifier; usually an enum. Event requests convey
+/// A temporal event is one that has its durability conveyed.
+pub trait TemporalEvent: Clone + DeserializeOwned + Serialize {}
+
+/// An event that has been logged, providing their identifier; usually an enum. These replies convey
 /// the offset they are associated with. If an offset overflows to zero then it is the
 /// server's responsibility to convey any important events that the client may need.
 /// It is the client's responsibility to clear state in relation to previous events when
-/// an offset less than or equal to the one it requested. An event request also conveys a
+/// an offset less than or equal to the one it requested is received. An event request also conveys a
 /// delta in time in a form that the client and its servers understand, and relative to
 /// the server's current notion of time.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Logged<E>(pub E, pub u32);
+impl<E: Clone + DeserializeOwned + Serialize> TemporalEvent for Logged<E> {}
+
+/// An event that has not been logged by the server and may be consumed by the client,
+/// often to convey some instantaneous event that does not need to be recorded. Events
+/// of this category should be benign if they are not consumed by a client.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Ephemeral<E>(pub E);
+impl<E: Clone + DeserializeOwned + Serialize> TemporalEvent for Ephemeral<E> {}
+
+/// Either a logged or an ephemeral event can be declared for use.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum Either<E, EE> {
+    Logged(E, u32),
+    Ephemeral(EE),
+}
+impl<E: Clone + DeserializeOwned + Serialize, EE: Clone + DeserializeOwned + Serialize>
+    TemporalEvent for Either<E, EE>
+{
+}
+
+/// An EventRequest may only be emitted by a server, of which there can be many, and
+/// only in relation to having received a [CommandRequest] from a client. Event replies
+/// take a temporal type that conveys their durability.
 ///
 /// An EventReply has the following little endian byte layout:
 ///
@@ -47,35 +74,32 @@ pub struct CommandRequest<C: DeserializeOwned + Serialize> {
 /// |          delta_ticks          | event |
 ///
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct EventReply<E: DeserializeOwned + Serialize> {
+pub struct EventReply<E: DeserializeOwned + Serialize + TemporalEvent> {
     /// The age of this event in relation to the server's notion of current time,
     /// expressed in a manner agreed between a client and server e.g. ticks can
     /// represent seconds.
     pub delta_ticks: u64,
-    /// The event to reply along with its offset. Offsets are expected to increment
-    /// by one each time. Therefore, it is possible for a client to determine if
-    /// there is an event missing and possibly re-request it.
+    /// The event to reply.
     #[serde(
         deserialize_with = "deserialise_last_field",
         serialize_with = "serialise_last_field"
     )]
-    pub event: Option<(E, u32)>,
+    pub event: Option<E>,
 }
 
-/// Given an event, offset and time, return an event reply containing it.
-pub fn event_reply<E, T, DS>(maybe_event: Option<&(E, u32, T)>, duration_since: DS) -> EventReply<E>
+/// Given an event and its time, return an event reply containing it.
+pub fn event_reply<E, T, DS>(maybe_event: Option<&(E, T)>, duration_since: DS) -> EventReply<E>
 where
     DS: FnOnce(T) -> u64,
-    E: Clone + DeserializeOwned + Serialize,
+    E: TemporalEvent,
     T: Copy,
 {
     // It is quite plausible that we have no events. In this case we
-    // reply with a "no more events" enum, an offset of 0 and a delta
-    // ticks of 0.
+    // reply with a "no more events" enum and delta ticks of 0.
     maybe_event
-        .map(|(e, o, t)| EventReply {
+        .map(|(e, t)| EventReply {
             delta_ticks: duration_since(*t),
-            event: Some((e.clone(), *o)),
+            event: Some(e.clone()),
         })
         .unwrap_or_else(|| EventReply {
             delta_ticks: 0,
@@ -166,16 +190,16 @@ mod tests {
             SomeOtherEvent,
         }
 
-        let reply = event_reply(Some(&(Event::SomeOtherEvent, 9, 0)), |_| 10);
+        let reply = event_reply(Some(&(Logged(Event::SomeOtherEvent, 9), 0)), |_| 10);
 
         let mut buf = [0; 32];
         let serialised = postcard::to_slice(&reply, &mut buf).unwrap();
         assert_eq!(serialised, [10, 1, 9]);
         assert_eq!(
-            postcard::from_bytes::<EventReply<Event>>(serialised).unwrap(),
+            postcard::from_bytes::<EventReply<Logged<Event>>>(serialised).unwrap(),
             EventReply {
                 delta_ticks: 10,
-                event: Some((Event::SomeOtherEvent, 9)),
+                event: Some(Logged(Event::SomeOtherEvent, 9)),
             }
         );
     }
@@ -188,16 +212,60 @@ mod tests {
             SomeOtherEvent,
         }
 
-        let reply = event_reply::<Event, u32, _>(None, |_| 10);
+        let reply: EventReply<Logged<Event>> = event_reply(None, |_: i32| 10);
 
         let mut buf = [0; 32];
         let serialised = postcard::to_slice(&reply, &mut buf).unwrap();
         assert_eq!(serialised, [0]);
         assert_eq!(
-            postcard::from_bytes::<EventReply<Event>>(serialised).unwrap(),
+            postcard::from_bytes::<EventReply<Logged<Event>>>(serialised).unwrap(),
             EventReply {
                 delta_ticks: 0,
                 event: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_event_serialisation_with_either() {
+        #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+        enum Event {
+            SomeEvent,
+            SomeOtherEvent,
+        }
+
+        #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+        enum Telemetry {
+            SomeTelemetry,
+        }
+
+        let reply: EventReply<Either<Event, Telemetry>> =
+            event_reply(Some(&(Either::Logged(Event::SomeOtherEvent, 9), 0)), |_| 10);
+
+        let mut buf = [0; 32];
+        let serialised = postcard::to_slice(&reply, &mut buf).unwrap();
+        assert_eq!(serialised, [10, 0, 1, 9]);
+        assert_eq!(
+            postcard::from_bytes::<EventReply<Either<Event, Telemetry>>>(serialised).unwrap(),
+            EventReply {
+                delta_ticks: 10,
+                event: Some(Either::Logged(Event::SomeOtherEvent, 9)),
+            }
+        );
+
+        let reply: EventReply<Either<Event, Telemetry>> = event_reply(
+            Some(&(Either::Ephemeral(Telemetry::SomeTelemetry), 0)),
+            |_| 10,
+        );
+
+        let mut buf = [0; 32];
+        let serialised = postcard::to_slice(&reply, &mut buf).unwrap();
+        assert_eq!(serialised, [10, 1, 0]);
+        assert_eq!(
+            postcard::from_bytes::<EventReply<Either<Event, Telemetry>>>(serialised).unwrap(),
+            EventReply {
+                delta_ticks: 10,
+                event: Some(Either::Ephemeral(Telemetry::SomeTelemetry)),
             }
         );
     }

--- a/data/src/update.rs
+++ b/data/src/update.rs
@@ -23,6 +23,7 @@ impl defmt::Format for UpdateKey {
 /// a numeric identifer.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum PreRelease {
     Alpha(u8),
     Beta(u8),

--- a/offset-rules.md
+++ b/offset-rules.md
@@ -1,4 +1,4 @@
-# Event Offsets
+# Logged Event Offsets
 
 The offset of an event is a number in the range `0 ..= N-1`  assigned by a server to an event when it is generated.    
 


### PR DESCRIPTION
The allowance for ephemeral events is introduced for the scenario where if they are missed by a client then there is no great concern. For example, if a server wishes to convey instantaneous electrical readings.

Fixes #15