### PR TITLE
Makes recovery a first-class protocol concern

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Lint
       env:
         RUSTFLAGS: -Dwarnings
-      run: cargo clippy
+      run: cargo clippy --tests
 
     - name: Format
       run: cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -22,13 +22,11 @@ Logged event delivery is reliable in the face of transport errors. Other failure
 
 ## Logged Event Delivery
 
-A numeric _offset_ is assigned to each event by the server that generates it. The client tracks the offset of the latest event successfully received from each server.  Each command or poll sent by the client carries this offset. The server normally responds with the following logged event, or either an ephemeral event or none if the client's offset is up to date. 
+A numeric _offset_ is assigned to each event by the server that generates it. The client tracks the offset of the latest event successfully received from each server.  Each command or poll sent by the client carries this offset. The server normally responds with the following logged event, or either an ephemeral event, an event indicating client-side state recovery, or none if the client's offset is up to date. 
 
 A server maintains a short history of logged events. This enables a client to request the same event more than once, in the case of a transport error.  In general the client can fall behind the server by the length of the history. 
 
-A loss of synchronization between client and server occurs when neither the client's offset nor its successor is found in the server's history.  This indicates an overrun where more logged events were generated on the server than could be stored or delivered.  Alternatively, either the client or the server may have restarted.  In either case application specific recovery may be required.   
-
-The protocol requires the server to deliver the oldest logged event in its history in this scenario.  The client detects the loss of synchronization when the received logged event does not have the expected offset.
+A loss of synchronization between client and server occurs when neither the client's offset nor its successor is found in the server's history.  This indicates an overrun where more logged events were generated on the server than could be stored or delivered.  Alternatively, either the client or the server may have restarted.  In either case application specific recovery may be required and is signalled by a special "recovery" event.
 
 Details of offset calculation and assignment to events are given in [offset-rules.md](offset-rules.md).
 

--- a/data/src/discovery.rs
+++ b/data/src/discovery.rs
@@ -253,8 +253,7 @@ mod tests {
                 .iter()
                 .enumerate()
                 .skip(1)
-                .skip_while(|(_, is_set)| !*is_set)
-                .next(),
+                .find(|(_, is_set)| *is_set),
             Some((3, true))
         );
     }

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// The size of a data frame header including the byte length for the payload.
 /// The byte length value is not to exceed 127.
-pub const HEADER_SIZE: usize = 5;
+pub const HEADER_SIZE: usize = 6;
 
 /// The size of the MIC code at the tail of the payload
 pub const MIC_SIZE: usize = 4;

--- a/data/src/update.rs
+++ b/data/src/update.rs
@@ -64,8 +64,8 @@ impl Display for Version {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
         match self.pre {
-            Some(PreRelease::Alpha(ident)) => write!(f, "-alpha.{}", ident),
-            Some(PreRelease::Beta(ident)) => write!(f, "-beta.{}", ident),
+            Some(PreRelease::Alpha(ident)) => write!(f, "-alpha.{ident}"),
+            Some(PreRelease::Beta(ident)) => write!(f, "-beta.{ident}"),
             None => Ok(()),
         }
     }

--- a/offset-rules.md
+++ b/offset-rules.md
@@ -18,7 +18,7 @@ Case |Condition |Response
 -|-|-
 1 |Event `s(n)` is present in history |Event `s(n)` 
 2 |Event `n` is present in history and event `s(n)` is not | No event
-3 |Otherwise |Earliest event available, offset `n0`
+3 |Otherwise |A recovery event conveying the start (n0) and end (n1) offsets available
 
 The client interprets the response as follows:
 
@@ -26,10 +26,12 @@ Case |Interpretation |Next Action
 -|-|-
 1 |Success |Poll with offset `s(n)`
 2 |Success |Poll or command with offset `n`
-3 |Failure |Application specific recovery, poll or command with offset `n0`
+3 |Failure |Recovery of client state from event by polling with offset `n0` upto and including offset `n1`.
 Transport error |Failure |Poll with offset `n`
 
-Case 3 indicates that the client or server has restarted or the server event buffer has overrun and a number of events have been lost.  If the client tracks some aspect of the server's state this must be recovered.  The means to do this are application specific.
+Case 3 indicates that the client or server has restarted or the server event buffer has overrun and a number of events have been lost. If the client tracks some aspect of the server's state this must be recovered. The means to do this are application specific, although given a start and end offset, a client can detect when it is in a recovery phase. A recovery
+phase begins on receipt of an event indicating the start and end offsets and continues while the client consumes events
+from the start offset up to and including the end offset.
 
 Note that the server has to generate at least one event after restart for the restart to be detected.
 


### PR DESCRIPTION
By issuing a recovery event as an additional variant alongside logged and ephemeral events, a server can signal that a client must recover.

This entails conveying an unknown offset in a request as a `None`, instead of `0`. The server can then differentiate and relax if `None` is provided (as before, the first event would be returned). This takes up an extra byte on the wire, but we need it.

I have also removed some of the event types that I had as they were mostly there for convenience in terms of the examples we had. Now that recovery is a variant, the convenience types are not applicable.

The examples have been updated to illustrate recovery mode.

The following client log indicates the effect of passing in None as the last event offset i.e. the first event the server has is returned:

```
CLIENT: listening on 0.0.0.0:0
CLIENT: CommandRequest { last_event_offset: None, command: None } command sent to 127.0.0.1:8080
CLIENT: event time 2023-02-21T12:24:17.403560+11:00 EventReply { delta_ticks: 5, event: Some(Logged(SomeEvent, 9)) } event 0 received from 127.0.0.1:8080
CLIENT: CommandRequest { last_event_offset: Some(9), command: None } command sent to 127.0.0.1:8080
CLIENT: event time 2023-02-21T12:24:19.404824+11:00 EventReply { delta_ticks: 4, event: Some(Logged(SomeEvent, 10)) } event 1 received from 127.0.0.1:8080
```

Sometime later, the server loses its state and the client responds to a recovery event:

```
CLIENT: CommandRequest { last_event_offset: Some(33), command: None } command sent to 127.0.0.1:8080
CLIENT: event time 2023-02-21T12:24:47.405710+11:00 EventReply { delta_ticks: 0, event: Some(Recovery(2, 2)) } event 25 received from 127.0.0.1:8080
CLIENT: Previous events for this server are now forgotten given an offset != what we expected.
CLIENT: Recovery complete.
CLIENT: CommandRequest { last_event_offset: Some(2), command: None } command sent to 127.0.0.1:8080
CLIENT: event time 2023-02-21T12:24:48.405384+11:00 EventReply { delta_ticks: 0, event: None } event 0 received from 127.0.0.1:8080
CLIENT: CommandRequest { last_event_offset: Some(2), command: None } command sent to 127.0.0.1:8080
CLIENT: event time 2023-02-21T12:24:49.405215+11:00 EventReply { delta_ticks: 0, event: Some(Logged(SomeEvent, 3)) } event 0 received from 127.0.0.1:8080
```

Thanks for the suggestion @arnolddevos. 