### PR TITLE
Return a result from decoding

### DIFF
--- a/data/examples/discovery/main.rs
+++ b/data/examples/discovery/main.rs
@@ -116,6 +116,7 @@ mod client {
             |h| h.server_address == 0x00 && h.server_port == 0x00 && h.source == DataSource::Server,
             cipher,
         )
+        .ok()
         .and_then(|(_, b)| postcard::from_bytes::<Identified>(&b).ok())
     }
 }
@@ -164,6 +165,7 @@ mod server {
             |h| h.server_address == 0x00 && h.server_port == 0x00 && h.source == DataSource::Client,
             cipher,
         )
+        .ok()
         .and_then(|(_, b)| postcard::from_bytes::<Identify>(&b).ok())
     }
 

--- a/data/examples/update/main.rs
+++ b/data/examples/update/main.rs
@@ -275,6 +275,7 @@ mod server {
             |h| h.server_address == 0x00 && h.server_port == 0x01 && h.source == DataSource::Client,
             cipher,
         )
+        .ok()
         .and_then(|(_, b)| postcard::from_bytes::<Update<N>>(&b).ok())
     }
 
@@ -324,6 +325,7 @@ mod server {
             |h| h.server_address == 0x00 && h.server_port == 0x01 && h.source == DataSource::Client,
             cipher,
         )
+        .ok()
         .and_then(|(_, b)| postcard::from_bytes::<PrepareForUpdate>(&b).ok())
     }
 


### PR DESCRIPTION
A result is now returned when decoding a datagram so that we can inspect more in terms of packets being dropped.